### PR TITLE
handlebars and options

### DIFF
--- a/lib/auton.js
+++ b/lib/auton.js
@@ -16,13 +16,19 @@
   module.exports.Compiler = Compiler;
   module.exports.VERSION  = VERSION;
 
-  function Compiler( rootDir, outputDir, watchMode ) {
+  function Compiler( rootDir, outputDir, watchMode, options ) {
     this.rootDir   = rootDir;
     this.outputDir = outputDir;
     this.watchMode = !!watchMode;
     this.rules     = [];
     this.ignores   = [];
     this.waitTime  = 100; // time to wait for write after noticing a change
+    this.options   = options || { };
+    
+    if (options.waitTime !== undefined) {
+      this.waitTime = options.waitTime;
+    }
+    
     return this;
   }
   
@@ -132,7 +138,8 @@
       rule:     rule,
       path:     file,
       save:     {   },
-      savedFilenames: [ ]
+      savedFilenames: [ ],
+      options:  this.options
     },
     makeCyan = function(x){ return colorize.ansify("#cyan[" + x + "]"); },
     go = function() {

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -15,11 +15,12 @@ var plugins   = {},
 
 
   plugins.handlebars = function(next) {
-    var data = this.data;
-    var template = this.options.templates || 'Templates';
+    var data     = this.data,
+        filename = path.basename( this.path, path.extname( this.path ) ),
+        template = this.options.templates || 'Templates';
     this.data = "/" + "* Compiled from " + this.path + " *"+ "/\n" +
                 "var " + template + " = " + template + " || { };\n" +
-                template + "[" + this.path + "] = Handlebars.template(" + handlebars.precompile(data) +");\n";
+                template + "['" + filename + "'] = Handlebars.template(" + handlebars.precompile(data) +");\n";
     this.save['plain']    = this.data;
     next();
   };

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -10,8 +10,19 @@ var plugins   = {},
     jshint  = require( 'jshint' ).JSHINT,
     util    = require( 'util' ),
     fs      = require( 'fs' ),
-    path    = require( 'path' );
+    path    = require( 'path' ),
+    handlebars = require( 'handlebars');
 
+
+  plugins.handlebars = function(next) {
+    var data = this.data;
+    this.data = "/" + "* Compiled from " + this.path + " *"+ "/\n" +
+                "var Templates = Templates || { };\n" +
+                "Templates[" + this.path + "] = Handlebars.template(" + handlebars.precompile(data) +");\n";
+    this.save['plain']    = this.data;
+    next();
+  };
+  
   plugins.coffee = function(next) {
     try {
       this.data       = coffee.compile( this.data );
@@ -245,10 +256,11 @@ plugins.util.makeSaveFunction = function mkSave( ext ) {
 
 plugins.rules = {};
 
-plugins.rules.js     = [plugins.read, plugins.jshint, plugins.uglify, plugins.gzip, plugins.save] ;
-plugins.rules.css    = [plugins.read,                 plugins.cssmin, plugins.gzip, plugins.save] ;
-plugins.rules.stylus = [plugins.read, plugins.stylus, plugins.cssmin, plugins.gzip, plugins.save] ;
-plugins.rules.coffee = [plugins.read, plugins.coffee, plugins.uglify, plugins.gzip, plugins.save] ;
+plugins.rules.js         = [plugins.read, plugins.jshint,     plugins.uglify, plugins.gzip, plugins.save] ;
+plugins.rules.css        = [plugins.read,                     plugins.cssmin, plugins.gzip, plugins.save] ;
+plugins.rules.stylus     = [plugins.read, plugins.stylus,     plugins.cssmin, plugins.gzip, plugins.save] ;
+plugins.rules.coffee     = [plugins.read, plugins.coffee,     plugins.uglify, plugins.gzip, plugins.save] ;
+plugins.rules.handlebars = [plugins.read, plugins.handlebars, plugins.uglify, plugins.gzip, plugins.save] ;
 
 
 module.exports   = plugins;

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -16,9 +16,10 @@ var plugins   = {},
 
   plugins.handlebars = function(next) {
     var data = this.data;
+    var template = this.options.templates || 'Templates';
     this.data = "/" + "* Compiled from " + this.path + " *"+ "/\n" +
-                "var Templates = Templates || { };\n" +
-                "Templates[" + this.path + "] = Handlebars.template(" + handlebars.precompile(data) +");\n";
+                "var " + template + " = " + template + " || { };\n" +
+                template + "[" + this.path + "] = Handlebars.template(" + handlebars.precompile(data) +");\n";
     this.save['plain']    = this.data;
     next();
   };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "coffee-script": ">=1.1.1",
     "watch-tree-maintained":    ">=0.1.2",
     "asyncjs":       ">=0.0.5",
-    "colorize":      ">=0.1.0"
+    "colorize":      ">=0.1.0",
+    "handlebars":    ">=1.0.0"
   },
   "devDependencies": {},
   "licenses":     [{


### PR DESCRIPTION
Added handlebars compilation support, as well as the ability to pass in an options object.   Currently, if options.templates exists, handlebars will use that as the template variable name when building.  This is very basic, and may make more sense passing in a JavaScript code snippet instead in the future.

```
var compiler = new Compiler('build', 'htdocs', true, { templates: "Templates" });

compiler.addRule( /\.handlebars$/, saveJs, rules.handlebars );
```
